### PR TITLE
Remove service.version from list of attributes with dedicated env var

### DIFF
--- a/docs/resource/README.md
+++ b/docs/resource/README.md
@@ -62,7 +62,6 @@ These are the attributes which MAY be configurable via a dedicated environment v
 as specified in [OpenTelemetry Environment Variable Specification](https://github.com/open-telemetry/opentelemetry-specification/tree/v1.22.0/specification/configuration/sdk-environment-variables.md):
 
 - [`service.name`](#service)
-- [`service.version`](#service)
 
 ## Semantic Attributes with SDK-provided Default Value
 


### PR DESCRIPTION
## Changes

Removes service.version from list of attributes with an env var. I tried looking for it but couldn't find it, it seems there was an attempt to add that wasn't merged

https://github.com/open-telemetry/opentelemetry-specification/pull/3573

I'm not sure if that will be revived but if it does, I guess this could be added back after the variable gets defined.

## Merge requirement checklist

* [X] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] [CHANGELOG.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md) updated for non-trivial changes.
* [ ] [schema-next.yaml](https://github.com/open-telemetry/semantic-conventions/blob/main/schema-next.yaml) updated with changes to existing conventions.

Didn't add to CHANGELOG since it's just a docs change, not spec change, but let me know if it should be there